### PR TITLE
add containerlab managed flag to nodesecurityprofile

### DIFF
--- a/clab_connector/templates/nodesecurityprofile.yaml.j2
+++ b/clab_connector/templates/nodesecurityprofile.yaml.j2
@@ -5,7 +5,8 @@ metadata:
   namespace: {{ namespace }}
 spec:
   nodeSelector:
-    - eda.nokia.com/security-profile=managed
+    - eda.nokia.com/security-profile=managed,containerlab=managedSrl
+    - eda.nokia.com/security-profile=managed,containerlab=managedSros
   tls:
     csrParams:
       certificateValidity: 2160h


### PR DESCRIPTION
having some weird issues having nodesecurity profiles mixed with hw,clab fabrics:
```
❯ k get targetnodes -A
NAMESPACE          NAME           NODESECURITYPROFILE            STATUS   DHCP           ADDRESS         PORT
clab-backend-fab   dc-gw-1        clab-backend-fab-managed-tls   Ready                   192.168.70.30   57400
clab-backend-fab   dc-gw-2        managed-tls                    Ready                   192.168.70.31   57400
clab-backend-fab   leaf-1         clab-backend-fab-managed-tls   Ready                   192.168.70.34   57410
clab-backend-fab   leaf-2         clab-backend-fab-managed-tls   Ready                   192.168.70.35   57410
clab-backend-fab   leaf-3         managed-tls                    Ready                   192.168.70.36   57410
clab-backend-fab   leaf-4         clab-backend-fab-managed-tls   Ready                   192.168.70.37   57410
clab-backend-fab   spine-1        managed-tls                    Ready                   192.168.70.32   57410
clab-backend-fab   spine-2        clab-backend-fab-managed-tls   Ready                   192.168.70.33   57410
eda                terzo-leaf1    clab-backend-fab-managed-tls   Ready    Acknowledged   192.168.70.10   57400
eda                terzo-leaf2    managed-tls                    Ready    Offered        192.168.70.11   57400
eda                terzo-spine1   managed-tls                    Ready    Acknowledged   192.168.70.9    57400
 
```
This PR should do it