### PR TITLE
Workaround for issue with cEOS nodes when no SSH public keys are found

### DIFF
--- a/clab_connector/templates/node-user.j2
+++ b/clab_connector/templates/node-user.j2
@@ -11,11 +11,9 @@ spec:
         - sudo
       nodeSelector:
         - {{ node_selector }}
-  sshPublicKeys:
   {%- if ssh_pub_keys and ssh_pub_keys|length > 0 %}
+  sshPublicKeys:
   {% for key in ssh_pub_keys %}
     - {{ key }}
   {% endfor %}
-  {%- else %}
-    []
   {%- endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clab-connector"
-version = "0.7.0"
+version = "0.7.1"
 description = "EDA Containerlab Connector"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "clab-connector"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
Workaround for issue with cEOS nodes when no SSH public keys are found