### PR TITLE
Adapting node profile of SRL nodes to enable cx spin up in branch

### DIFF
--- a/clab_connector/models/node/nokia_srl.py
+++ b/clab_connector/models/node/nokia_srl.py
@@ -30,6 +30,7 @@ class NokiaSRLinuxNode(Node):
     SRL_IMAGE_MD5 = "eda-system/srlimages/srlinux-{version}-bin/srlinux.bin.md5"
     CONTAINER_IMAGE = "ghcr.io/nokia/srlinux:{version}"
     IMAGE_PULL_SECRET = "core"
+    LICENSE = "cx-srl-{version_dashes}-ghcr-license"
     LLM_DB_PATH = "https://eda-asvr.eda-system.svc/eda-system/llm-dbs/llm-db-srlinux-ghcr-{version}/llm-embeddings-srl-{version_dashes}.tar.gz"
 
     # Mapping for EDA operating system
@@ -222,6 +223,9 @@ class NokiaSRLinuxNode(Node):
             "sw_image_md5": self.SRL_IMAGE_MD5.format(version=self.version),
             "container_image": self.CONTAINER_IMAGE.format(version=self.version),
             "image_pull_secret": self.IMAGE_PULL_SECRET,
+            "license": self.LICENSE.format(
+                version_dashes=self.version.replace(".", "-")
+            ),
             "llm_db": self.LLM_DB_PATH.format(
                 version=self.version, version_dashes=self.version.replace(".", "-")
             ),

--- a/clab_connector/models/node/nokia_srl.py
+++ b/clab_connector/models/node/nokia_srl.py
@@ -28,6 +28,8 @@ class NokiaSRLinuxNode(Node):
     YANG_PATH = "https://eda-asvr.eda-system.svc/eda-system/clab-schemaprofiles/{artifact_name}/{filename}"
     SRL_IMAGE = "eda-system/srlimages/srlinux-{version}-bin/srlinux.bin"
     SRL_IMAGE_MD5 = "eda-system/srlimages/srlinux-{version}-bin/srlinux.bin.md5"
+    CONTAINER_IMAGE = "ghcr.io/nokia/srlinux:{version}"
+    IMAGE_PULL_SECRET = "core"
     LLM_DB_PATH = "https://eda-asvr.eda-system.svc/eda-system/llm-dbs/llm-db-srlinux-ghcr-{version}/llm-embeddings-srl-{version_dashes}.tar.gz"
 
     # Mapping for EDA operating system
@@ -218,6 +220,8 @@ class NokiaSRLinuxNode(Node):
             "onboarding_username": self.SRL_USERNAME,
             "sw_image": self.SRL_IMAGE.format(version=self.version),
             "sw_image_md5": self.SRL_IMAGE_MD5.format(version=self.version),
+            "container_image": self.CONTAINER_IMAGE.format(version=self.version),
+            "image_pull_secret": self.IMAGE_PULL_SECRET,
             "llm_db": self.LLM_DB_PATH.format(
                 version=self.version, version_dashes=self.version.replace(".", "-")
             ),

--- a/clab_connector/services/integration/topology_integrator.py
+++ b/clab_connector/services/integration/topology_integrator.py
@@ -278,10 +278,10 @@ class TopologyIntegrator:
         """
         Create a NodeSecurityProfile resource that references an EDA node issuer.
         """
-        data = {"namespace": self.topology.namespace}
+        data = {"namespace": "eda-system"}
         yaml_str = helpers.render_template("nodesecurityprofile.yaml.j2", data)
         try:
-            apply_manifest(yaml_str, namespace=self.topology.namespace)
+            apply_manifest(yaml_str, namespace="eda-system")
             logger.info(f"{SUBSTEP_INDENT}Node security profile created.")
         except RuntimeError as ex:
             if "AlreadyExists" in str(ex):

--- a/clab_connector/services/manifest/manifest_generator.py
+++ b/clab_connector/services/manifest/manifest_generator.py
@@ -108,7 +108,7 @@ class ManifestGenerator:
 
         # --- Node Security Profile
         nsp_yaml = helpers.render_template(
-            "nodesecurityprofile.yaml.j2", {"namespace": namespace}
+            "nodesecurityprofile.yaml.j2", {"namespace": "eda-system"}
         )
         self.cr_groups["node-security-profile"] = [nsp_yaml]
 

--- a/clab_connector/templates/node-profile.j2
+++ b/clab_connector/templates/node-profile.j2
@@ -29,6 +29,10 @@ spec:
 {% if license is defined %}
   license: {{ license }}
 {% endif %}
+{% if container_image is defined %}
+  containerImage: {{ container_image }}
+  imagePullSecret: {{ image_pull_secret }}
+{% endif %}
 {% if llm_db is defined %}
   llmDb: {{ llm_db }}
 {% endif %}


### PR DESCRIPTION
Adding containerimage, imagepullsecret and reference to cx-license config map so that cx containers can be created when creating a branch.
Further moved unused and unreconciled node security profile to eda-system namespace to make the reconciliation alarm disappear.