### PR TITLE
SROS sr-7s FP4 fix and introduce sros fp5 modular variants

### DIFF
--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -104,32 +104,32 @@ class NokiaSROSNode(Node):
          ##### FP5 modules 
          ### SR-1
         "sr-1x-48d": {
-            "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
+            #"lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
             "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
             "connectors": 48,  # Number of connectors
         },
         "sr-1-24d": {
-            "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
+            #"lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
             "connectors": 24,  # Number of connectors
         },
         "sr-1-48d": {
-            "lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
+            #"lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
             "connectors": 48,  # Number of connectors
         },
         "sr-1-92s": {
-            "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
+            #"lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
             "connectors": 92,  # Number of connectors
         },
         "sr-1-46s": {
-            "lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
+            #"lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
             "connectors": 46,  # Number of connectors
         },
         "sr-1x-92s": {
-            "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
+            #"lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "connectors": 92,  # Number of connectors
         },

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -106,32 +106,32 @@ class NokiaSROSNode(Node):
         "sr-1x-48d": {
             "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
             "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
-            "connectors": 12,  # Number of connectors
+            "connectors": 48,  # Number of connectors
         },
         "sr-1-24d": {
             "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
-            "connectors": 12,  # Number of connectors
+            "connectors": 24,  # Number of connectors
         },
         "sr-1-48d": {
             "lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
-            "connectors": 12,  # Number of connectors
+            "connectors": 48,  # Number of connectors
         },
         "sr-1-92s": {
             "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
-            "connectors": 12,  # Number of connectors
+            "connectors": 92,  # Number of connectors
         },
         "sr-1-46s": {
             "lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
-            "connectors": 12,  # Number of connectors
+            "connectors": 46,  # Number of connectors
         },
         "sr-1x-92s": {
             "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
-            "connectors": 12,  # Number of connectors
+            "connectors": 92,  # Number of connectors
         },
         ### SR-1se
         "sr-1se": {

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -103,32 +103,32 @@ class NokiaSROSNode(Node):
          },
          ##### FP5 modules 
          ### SR-1
-        "sr-1x-48d": {
+        "sr-1x-48D": {
             #"lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
             #"mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
             "connectors": 48,  # Number of connectors
         },
-        "sr-1-24d": {
+        "sr-1-24D": {
             "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
             "connectors": 24,  # Number of connectors
         },
-        "sr-1-48d": {
+        "sr-1-48D": {
             #"lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
             "connectors": 48,  # Number of connectors
         },
-        "sr-1-92s": {
+        "sr-1-92S": {
             #"lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
             "connectors": 92,  # Number of connectors
         },
-        "sr-1-46s": {
+        "sr-1-46S": {
             #"lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
             "connectors": 46,  # Number of connectors
         },
-        "sr-1x-92s": {
+        "sr-1x-92S": {
             #"lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "connectors": 92,  # Number of connectors

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -136,8 +136,6 @@ class NokiaSROSNode(Node):
         ### SR-1se
         "sr-1se": {
             "lineCard": {"slot": "1", "type": "imm36-800g-qsfpdd"},
-            "powerShelf": {"slot": "1", "type": "ps-a4-shelf-dc"},
-            "powerModule": {"slot": "1-1,1-2,1-3,1-4", "type": "ps-a-dc-6000"},
             "mda": {"slot": "1-a", "type": "ms36-800g-qsfpdd"},
             "connectors": 36,
         },

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -101,38 +101,38 @@ class NokiaSROSNode(Node):
              "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
              "connectors": 36,
          },
-         ##### FP5 models 
+         ##### FP5 models - TODO
          ### SR-1
-        "sr-1x-48d": {
-            "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
-            "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
-            "connectors": 48,  # Number of connectors
-        },
-        "sr-1-24d": {
-            "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
-            "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
-            "connectors": 24,  # Number of connectors
-        },
-        "sr-1-48d": {
-            "lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
-            "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
-            "connectors": 48,  # Number of connectors
-        },
-        "sr-1-92s": {
-            "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
-            "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
-            "connectors": 92,  # Number of connectors
-        },
-        "sr-1-46s": {
-            "lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
-            "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
-            "connectors": 46,  # Number of connectors
-        },
-        "sr-1x-92s": {
-            "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
-            "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
-            "connectors": 92,  # Number of connectors
-        },
+        #"sr-1x-48d": {
+        #    "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
+        #    "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
+        #    "connectors": 48,  # Number of connectors
+        #},
+        #"sr-1-24d": {
+        #    "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
+        #    "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
+        #    "connectors": 24,  # Number of connectors
+        #},
+        #"sr-1-48d": {
+        #    "lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
+        #    "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
+        #    "connectors": 48,  # Number of connectors
+        #},
+        #"sr-1-92s": {
+        #    "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
+        #    "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
+        #    "connectors": 92,  # Number of connectors
+        #},
+        #"sr-1-46s": {
+        #    "lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
+        #    "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
+        #    "connectors": 46,  # Number of connectors
+        #},
+        #"sr-1x-92s": {
+        #    "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
+        #    "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
+        #    "connectors": 92,  # Number of connectors
+        #},
         ### SR-1se
         "sr-1se": {
             "lineCard": {"slot": "1", "type": "imm36-800g-qsfpdd"},
@@ -241,44 +241,23 @@ class NokiaSROSNode(Node):
         """
         return "sr7750"  # Default to 7750 SR router type
 
-def get_platform(self):
-    """
-    Return the platform name based on node type.
+    def get_platform(self):
+        """
+        Return the platform name based on node type.
 
-    Returns
-    -------
-    str
-        The platform name (e.g. '7750 SR-1', 'SR-1-48D', 'SR-2se').
-    """
-    if self.node_type and self.node_type.lower().startswith("sr-"):
-        # The platform string must match exactly the type reported by gNMIc, as EDA performs a case-sensitive platform comparison.
-        #
-        # Examples:
-        #   sr-1-48d   -> 7750 SR-1-48D
-        #   SR-1X-92S  -> 7750 SR-1x-92S
-        #   sr-1s      -> 7750 SR-1s
-        #   SR-2SE     -> 7750 SR-2se
-        #
-        # Rules:
-        # - Always uppercase the "SR" prefix.
-        # - For fixed-port platforms (SR-1-* and SR-1x-*), normalize the family to lowercase (1x) and uppercase only the final port designator (D/S), matching the value reported by gNMI.
-        # - For chassis platforms (SR-1s, SR-2se, SR-14s, ...), normalize the model suffix to lowercase.
-
-        node = self.node_type.strip()
-
-        # Normalize the SR prefix.
-        node = "SR-" + node[3:]
-
-        # Fixed-port platforms: SR-1-* and SR-1x-*.
-        match = re.fullmatch(r"SR-(1x|1)-(\d+)([a-z])", node, re.IGNORECASE)
-        if match:
-            family, ports, suffix = match.groups()
-            return f"7750 SR-{family.lower()}-{ports}{suffix.upper()}"
-
-        # Chassis platforms: normalize everything after "SR-" to lowercase.
-        return f"7750 SR-{node[3:].lower()}"
-
-    return "7750 SR"  # Default fallback
+        Returns
+        -------
+        str
+            The platform name (e.g. '7750 SR-1').
+        """
+        if self.node_type and self.node_type.lower().startswith("sr-"):
+            # For SR-1, SR-7, SR-1s, etc. - preserve the exact case
+            # Only uppercase the "SR" part, keep the suffix as-is
+            if "-" in self.node_type:
+                parts = self.node_type.split("-", 1)
+                return f"7750 {parts[0].upper()}-{parts[1]}"
+            return f"7750 {self.node_type.upper()}"
+        return "7750 SR"  # Default fallback
 
     def is_eda_supported(self):
         """

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -104,14 +104,13 @@ class NokiaSROSNode(Node):
          ##### FP5 models 
          ### SR-1
         "sr-1x-48d": {
-            #"lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
-            #"mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
-            #"connectors": 48,  # Number of connectors
+            "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
+            "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
+            "connectors": 48,  # Number of connectors
         },
         "sr-1-24d": {
             "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
-            "powerModule": {"slot": "1-1,1-2,1-3", "type": "ps-a-dc-6000"},
             "connectors": 24,  # Number of connectors
         },
         "sr-1-48d": {
@@ -242,23 +241,44 @@ class NokiaSROSNode(Node):
         """
         return "sr7750"  # Default to 7750 SR router type
 
-    def get_platform(self):
-        """
-        Return the platform name based on node type.
+def get_platform(self):
+    """
+    Return the platform name based on node type.
 
-        Returns
-        -------
-        str
-            The platform name (e.g. '7750 SR-1').
-        """
-        if self.node_type and self.node_type.lower().startswith("sr-"):
-            # For SR-1, SR-7, SR-1s, etc. - preserve the exact case
-            # Only uppercase the "SR" part, keep the suffix as-is
-            if "-" in self.node_type:
-                parts = self.node_type.split("-", 1)
-                return f"7750 {parts[0].upper()}-{parts[1]}"
-            return f"7750 {self.node_type.upper()}"
-        return "7750 SR"  # Default fallback
+    Returns
+    -------
+    str
+        The platform name (e.g. '7750 SR-1', 'SR-1-48D', 'SR-2se').
+    """
+    if self.node_type and self.node_type.lower().startswith("sr-"):
+        # The platform string must match exactly the type reported by gNMIc, as EDA performs a case-sensitive platform comparison.
+        #
+        # Examples:
+        #   sr-1-48d   -> 7750 SR-1-48D
+        #   SR-1X-92S  -> 7750 SR-1x-92S
+        #   sr-1s      -> 7750 SR-1s
+        #   SR-2SE     -> 7750 SR-2se
+        #
+        # Rules:
+        # - Always uppercase the "SR" prefix.
+        # - For fixed-port platforms (SR-1-* and SR-1x-*), normalize the family to lowercase (1x) and uppercase only the final port designator (D/S), matching the value reported by gNMI.
+        # - For chassis platforms (SR-1s, SR-2se, SR-14s, ...), normalize the model suffix to lowercase.
+
+        node = self.node_type.strip()
+
+        # Normalize the SR prefix.
+        node = "SR-" + node[3:]
+
+        # Fixed-port platforms: SR-1-* and SR-1x-*.
+        match = re.fullmatch(r"SR-(1x|1)-(\d+)([a-z])", node, re.IGNORECASE)
+        if match:
+            family, ports, suffix = match.groups()
+            return f"7750 SR-{family.lower()}-{ports}{suffix.upper()}"
+
+        # Chassis platforms: normalize everything after "SR-" to lowercase.
+        return f"7750 SR-{node[3:].lower()}"
+
+    return "7750 SR"  # Default fallback
 
     def is_eda_supported(self):
         """

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -88,8 +88,8 @@ class NokiaSROSNode(Node):
         },
         ## TODO: It doesn't work for some reason
          "sr-7s": {
-             "lineCard": {"slot": "1", "type": "xcm2-7s"},
-             "fabric": {"slot": "1", "type": "sfm2-s"},
+             "lineCard": {"slot": "1", "type": "xcm-7s"},
+             "fabric": {"slot": "1", "type": "sfm-s"},
              "powerShelf": [
                   {"slot": "1", "type": "ps-a10-shelf-dc"},
                   {"slot": "2", "type": "ps-a10-shelf-dc"},

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -105,11 +105,11 @@ class NokiaSROSNode(Node):
          ### SR-1
         "sr-1x-48d": {
             #"lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
-            "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
+            #"mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
             "connectors": 48,  # Number of connectors
         },
         "sr-1-24d": {
-            #"lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
+            "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
             "connectors": 24,  # Number of connectors
         },

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -87,52 +87,52 @@ class NokiaSROSNode(Node):
             "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
             "connectors": 36,
         },
-         "sr-7s": {   ### This is the FP4 only variant!! Does not support any FP5 related components 
-             "lineCard": {"slot": "1", "type": "xcm-7s"},
-             "fabric": {"slot": "1", "type": "sfm-s"},
-             "powerShelf": [
-                  {"slot": "1", "type": "ps-a10-shelf-dc"},
-                  {"slot": "2", "type": "ps-a10-shelf-dc"},
-             ],
-             "powerModule": [
+        "sr-7s": {  ### This is the FP4 only variant!! Does not support any FP5 related components
+            "lineCard": {"slot": "1", "type": "xcm-7s"},
+            "fabric": {"slot": "1", "type": "sfm-s"},
+            "powerShelf": [
+                {"slot": "1", "type": "ps-a10-shelf-dc"},
+                {"slot": "2", "type": "ps-a10-shelf-dc"},
+            ],
+            "powerModule": [
                 {"slot": "1-1,1-2", "type": "ps-a-dc-6000"},
                 {"slot": "1-3,1-4", "type": "ps-a-dc-6000"},
-             ],
-             "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
-             "connectors": 36,
-         },
-         ##### FP5 models - TODO
-         ### SR-1
-        #"sr-1x-48d": {
+            ],
+            "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
+            "connectors": 36,
+        },
+        ##### FP5 models - TODO
+        ### SR-1
+        # "sr-1x-48d": {
         #    "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
         #    "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
         #    "connectors": 48,  # Number of connectors
-        #},
-        #"sr-1-24d": {
+        # },
+        # "sr-1-24d": {
         #    "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
         #    "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
         #    "connectors": 24,  # Number of connectors
-        #},
-        #"sr-1-48d": {
+        # },
+        # "sr-1-48d": {
         #    "lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
         #    "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
         #    "connectors": 48,  # Number of connectors
-        #},
-        #"sr-1-92s": {
+        # },
+        # "sr-1-92s": {
         #    "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
         #    "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
         #    "connectors": 92,  # Number of connectors
-        #},
-        #"sr-1-46s": {
+        # },
+        # "sr-1-46s": {
         #    "lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
         #    "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
         #    "connectors": 46,  # Number of connectors
-        #},
-        #"sr-1x-92s": {
+        # },
+        # "sr-1x-92s": {
         #    "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
         #    "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
         #    "connectors": 92,  # Number of connectors
-        #},
+        # },
         ### SR-1se
         "sr-1se": {
             "lineCard": {"slot": "1", "type": "imm36-800g-qsfpdd"},
@@ -151,20 +151,20 @@ class NokiaSROSNode(Node):
             "connectors": 36,
         },
         ### SR-14s
-         "sr-14s": {   ### This is the FP5 only variant!! Does not support any FP4 related components 
-             "lineCard": {"slot": "1", "type": "xcm2-14s"},
-             "fabric": {"slot": "1", "type": "sfm2-s"},
-             "powerShelf": [
-                  {"slot": "1", "type": "ps-a10-shelf-dc"},
-                  {"slot": "2", "type": "ps-a10-shelf-dc"},
-             ],
-             "powerModule": [
+        "sr-14s": {  ### This is the FP5 only variant!! Does not support any FP4 related components
+            "lineCard": {"slot": "1", "type": "xcm2-14s"},
+            "fabric": {"slot": "1", "type": "sfm2-s"},
+            "powerShelf": [
+                {"slot": "1", "type": "ps-a10-shelf-dc"},
+                {"slot": "2", "type": "ps-a10-shelf-dc"},
+            ],
+            "powerModule": [
                 {"slot": "1-1,1-2", "type": "ps-a-dc-6000"},
                 {"slot": "1-3,1-4", "type": "ps-a-dc-6000"},
-             ],
-             "mda": {"slot": "1-a", "type": "x2-s36-800g-qsfpdd-18.0t"},
-             "connectors": 36,
-         },
+            ],
+            "mda": {"slot": "1-a", "type": "x2-s36-800g-qsfpdd-18.0t"},
+            "connectors": 36,
+        },
     }
 
     # Component kinds that accept a single dict or list of dicts (slot, type)

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -66,6 +66,7 @@ class NokiaSROSNode(Node):
 
     # Map of node types to their line card, power, MDA and connector components
     SROS_COMPONENTS: ClassVar[dict[str, dict[str, dict[str, str] | int]]] = {
+        ### FP4 models
         "sr-1": {
             "lineCard": {"slot": "1", "type": "iom-1"},
             "mda": {"slot": "1-a", "type": "me12-100gb-qsfp28"},
@@ -86,8 +87,7 @@ class NokiaSROSNode(Node):
             "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
             "connectors": 36,
         },
-        ## TODO: It doesn't work for some reason
-         "sr-7s": {
+         "sr-7s": {   ### This is the FP4 only variant!! Does not support any FP5 related components 
              "lineCard": {"slot": "1", "type": "xcm-7s"},
              "fabric": {"slot": "1", "type": "sfm-s"},
              "powerShelf": [
@@ -101,6 +101,7 @@ class NokiaSROSNode(Node):
              "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
              "connectors": 36,
          },
+         ### FP5 modules - TODO
     }
 
     # Component kinds that accept a single dict or list of dicts (slot, type)

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -101,16 +101,17 @@ class NokiaSROSNode(Node):
              "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
              "connectors": 36,
          },
-         ##### FP5 modules 
+         ##### FP5 models 
          ### SR-1
         "sr-1x-48d": {
-            "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
-            "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
-            "connectors": 48,  # Number of connectors
+            #"lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
+            #"mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
+            #"connectors": 48,  # Number of connectors
         },
         "sr-1-24d": {
             "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
+            "powerModule": {"slot": "1-1,1-2,1-3", "type": "ps-a-dc-6000"},
             "connectors": 24,  # Number of connectors
         },
         "sr-1-48d": {
@@ -150,6 +151,7 @@ class NokiaSROSNode(Node):
             "mda": {"slot": "1-a", "type": "x2-s36-800g-qsfpdd-18.0t"},
             "connectors": 36,
         },
+        ### SR-14s
          "sr-14s": {   ### This is the FP5 only variant!! Does not support any FP4 related components 
              "lineCard": {"slot": "1", "type": "xcm2-14s"},
              "fabric": {"slot": "1", "type": "sfm2-s"},

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -87,20 +87,20 @@ class NokiaSROSNode(Node):
             "connectors": 36,
         },
         ## TODO: It doesn't work for some reason
-        # "sr-7s": {
-        #     "lineCard": {"slot": "1", "type": "xcm2-7s"},
-        #     "fabric": {"slot": "1", "type": "sfm2-s"},
-        #     "powerShelf": [
-        #          {"slot": "1", "type": "ps-a10-shelf-dc"},
-        #          {"slot": "2", "type": "ps-a10-shelf-dc"},
-        #     ],
-        #     "powerModule": [
-        #        {"slot": "1-1,1,2", "type": "ps-a-dc-6000"},
-        #        {"slot": "1-3,1-4", "type": "ps-a-dc-6000"},
-        #     ],
-        #     "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
-        #     "connectors": 36,
-        # },
+         "sr-7s": {
+             "lineCard": {"slot": "1", "type": "xcm2-7s"},
+             "fabric": {"slot": "1", "type": "sfm2-s"},
+             "powerShelf": [
+                  {"slot": "1", "type": "ps-a10-shelf-dc"},
+                  {"slot": "2", "type": "ps-a10-shelf-dc"},
+             ],
+             "powerModule": [
+                {"slot": "1-1,1-2", "type": "ps-a-dc-6000"},
+                {"slot": "1-3,1-4", "type": "ps-a-dc-6000"},
+             ],
+             "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
+             "connectors": 36,
+         },
     }
 
     # Component kinds that accept a single dict or list of dicts (slot, type)

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -105,7 +105,7 @@ class NokiaSROSNode(Node):
          ### SR-1
         "sr-1x-48d": {
             "lineCard": {"slot": "1", "type": "iom-1"},
-            "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
+            "mda": {"slot": "1-a", "type": "i48-800g-qsfpdd-1x"},
             "connectors": 12,  # Number of connectors
         },
         "sr-1-24d": {
@@ -135,7 +135,7 @@ class NokiaSROSNode(Node):
         },
         ### SR-1se
         "sr-1se": {
-            "lineCard": {"slot": "1", "type": "xcm-1se"},
+            "lineCard": {"slot": "1", "type": "imm36-800g-qsfpdd"},
             "powerShelf": {"slot": "1", "type": "ps-a4-shelf-dc"},
             "powerModule": {"slot": "1-1,1-2,1-3,1-4", "type": "ps-a-dc-6000"},
             "mda": {"slot": "1-a", "type": "ms36-800g-qsfpdd"},

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -105,7 +105,7 @@ class NokiaSROSNode(Node):
          ### SR-1
         "sr-1x-48d": {
             "lineCard": {"slot": "1", "type": "iom-1"},
-            "mda": {"slot": "1-a", "type": "i48-800g-qsfpdd-1x"},
+            "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
             "connectors": 12,  # Number of connectors
         },
         "sr-1-24d": {
@@ -136,6 +136,8 @@ class NokiaSROSNode(Node):
         ### SR-1se
         "sr-1se": {
             "lineCard": {"slot": "1", "type": "imm36-800g-qsfpdd"},
+            "powerShelf": {"slot": "1", "type": "ps-a4-shelf-dc"},
+            "powerModule": {"slot": "1-1,1-2,1-3,1-4", "type": "ps-a-dc-6000"},
             "mda": {"slot": "1-a", "type": "ms36-800g-qsfpdd"},
             "connectors": 36,
         },

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -103,33 +103,33 @@ class NokiaSROSNode(Node):
          },
          ##### FP5 modules 
          ### SR-1
-        "sr-1x-48D": {
-            #"lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
-            #"mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
+        "sr-1x-48d": {
+            "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
+            "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
             "connectors": 48,  # Number of connectors
         },
-        "sr-1-24D": {
+        "sr-1-24d": {
             "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
             "connectors": 24,  # Number of connectors
         },
-        "sr-1-48D": {
-            #"lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
+        "sr-1-48d": {
+            "lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
             "connectors": 48,  # Number of connectors
         },
-        "sr-1-92S": {
-            #"lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
+        "sr-1-92s": {
+            "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
             "connectors": 92,  # Number of connectors
         },
-        "sr-1-46S": {
-            #"lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
+        "sr-1-46s": {
+            "lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
             "connectors": 46,  # Number of connectors
         },
-        "sr-1x-92S": {
-            #"lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
+        "sr-1x-92s": {
+            "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "connectors": 92,  # Number of connectors
         },

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -101,7 +101,69 @@ class NokiaSROSNode(Node):
              "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
              "connectors": 36,
          },
-         ### FP5 modules - TODO
+         ##### FP5 modules 
+         ### SR-1
+        "sr-1x-48d": {
+            "lineCard": {"slot": "1", "type": "iom-1"},
+            "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
+            "connectors": 12,  # Number of connectors
+        },
+        "sr-1-24d": {
+            "lineCard": {"slot": "1", "type": "iom-1"},
+            "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
+            "connectors": 12,  # Number of connectors
+        },
+        "sr-1-48d": {
+            "lineCard": {"slot": "1", "type": "iom-1"},
+            "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
+            "connectors": 12,  # Number of connectors
+        },
+        "sr-1-92s": {
+            "lineCard": {"slot": "1", "type": "iom-1"},
+            "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
+            "connectors": 12,  # Number of connectors
+        },
+        "sr-1-46s": {
+            "lineCard": {"slot": "1", "type": "iom-1"},
+            "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
+            "connectors": 12,  # Number of connectors
+        },
+        "sr-1x-92s": {
+            "lineCard": {"slot": "1", "type": "iom-1"},
+            "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
+            "connectors": 12,  # Number of connectors
+        },
+        ### SR-1se
+        "sr-1se": {
+            "lineCard": {"slot": "1", "type": "xcm-1se"},
+            "powerShelf": {"slot": "1", "type": "ps-a4-shelf-dc"},
+            "powerModule": {"slot": "1-1,1-2,1-3,1-4", "type": "ps-a-dc-6000"},
+            "mda": {"slot": "1-a", "type": "ms36-800g-qsfpdd"},
+            "connectors": 36,
+        },
+        ### SR-2se
+        "sr-2se": {
+            "lineCard": {"slot": "1", "type": "xcm-2se"},
+            "fabric": {"slot": "1", "type": "sfm-2se"},
+            "powerShelf": {"slot": "1", "type": "ps-a4-shelf-dc"},
+            "powerModule": {"slot": "1-1,1-2,1-3,1-4", "type": "ps-a-dc-6000"},
+            "mda": {"slot": "1-a", "type": "x2-s36-800g-qsfpdd-18.0t"},
+            "connectors": 36,
+        },
+         "sr-14s": {   ### This is the FP5 only variant!! Does not support any FP4 related components 
+             "lineCard": {"slot": "1", "type": "xcm2-7s"},
+             "fabric": {"slot": "1", "type": "sfm2-s"},
+             "powerShelf": [
+                  {"slot": "1", "type": "ps-a10-shelf-dc"},
+                  {"slot": "2", "type": "ps-a10-shelf-dc"},
+             ],
+             "powerModule": [
+                {"slot": "1-1,1-2", "type": "ps-a-dc-6000"},
+                {"slot": "1-3,1-4", "type": "ps-a-dc-6000"},
+             ],
+             "mda": {"slot": "1-a", "type": "x2-s36-800g-qsfpdd-18.0t"},
+             "connectors": 36,
+         },
     }
 
     # Component kinds that accept a single dict or list of dicts (slot, type)

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -124,12 +124,12 @@ class NokiaSROSNode(Node):
             "connectors": 12,  # Number of connectors
         },
         "sr-1-46s": {
-            "lineCard": {"slot": "1", "type": "cpm-1x/i40-200g-sfpdd+6-800g-qsfpdd-1"},
+            "lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
             "connectors": 12,  # Number of connectors
         },
         "sr-1x-92s": {
-            "lineCard": {"slot": "1", "type": "cpm-1x/i80-200g-sfpdd+12-800g-qsfpdd-1x"},
+            "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "connectors": 12,  # Number of connectors
         },

--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -104,32 +104,32 @@ class NokiaSROSNode(Node):
          ##### FP5 modules 
          ### SR-1
         "sr-1x-48d": {
-            "lineCard": {"slot": "1", "type": "iom-1"},
+            "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
             "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
             "connectors": 12,  # Number of connectors
         },
         "sr-1-24d": {
-            "lineCard": {"slot": "1", "type": "iom-1"},
+            "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
             "connectors": 12,  # Number of connectors
         },
         "sr-1-48d": {
-            "lineCard": {"slot": "1", "type": "iom-1"},
+            "lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
             "connectors": 12,  # Number of connectors
         },
         "sr-1-92s": {
-            "lineCard": {"slot": "1", "type": "iom-1"},
+            "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
             "connectors": 12,  # Number of connectors
         },
         "sr-1-46s": {
-            "lineCard": {"slot": "1", "type": "iom-1"},
+            "lineCard": {"slot": "1", "type": "cpm-1x/i40-200g-sfpdd+6-800g-qsfpdd-1"},
             "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
             "connectors": 12,  # Number of connectors
         },
         "sr-1x-92s": {
-            "lineCard": {"slot": "1", "type": "iom-1"},
+            "lineCard": {"slot": "1", "type": "cpm-1x/i80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
             "connectors": 12,  # Number of connectors
         },
@@ -151,7 +151,7 @@ class NokiaSROSNode(Node):
             "connectors": 36,
         },
          "sr-14s": {   ### This is the FP5 only variant!! Does not support any FP4 related components 
-             "lineCard": {"slot": "1", "type": "xcm2-7s"},
+             "lineCard": {"slot": "1", "type": "xcm2-14s"},
              "fabric": {"slot": "1", "type": "sfm2-s"},
              "powerShelf": [
                   {"slot": "1", "type": "ps-a10-shelf-dc"},


### PR DESCRIPTION
This includes the sr-7s FP4 variant fix. 
Issue was that LC was FP4 but SFM, XCM were the FP5 compatible variants.

This requires CLAB model to be deployed as FP4, e.g.:
```
    # FP4 chassis
    dc-gw-202:
      kind: nokia_srsim
      type: sr-7s
      license: /opt/nokia/sros/sr-sim_r25_license.key
      env:
        NOKIA_SROS_SFM: sfm-s 
      components:
        - slot: A
          sfm: sfm-s # FP4
          type: cpm2-s
        - slot: 1
          type: xcm-7s # FP4
          mda:
            - slot: 1
              type: s36-100gb-qsfp28 # FP4
```

I'll add a few FP5 variants in another PR.
Note: We need to think on how we could have sr-7s for fp5 and for fp5.  