### PR TITLE
SROS FP5 integrated models support (SR-1/SR-1x)

### DIFF
--- a/clab_connector/models/node/nokia_sros.py
+++ b/clab_connector/models/node/nokia_sros.py
@@ -101,38 +101,38 @@ class NokiaSROSNode(Node):
              "mda": {"slot": "1-a", "type": "s36-100gb-qsfp28"},
              "connectors": 36,
          },
-         ##### FP5 models - TODO
+         ##### FP5 models 
          ### SR-1
-        #"sr-1x-48d": {
-        #    "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
-        #    "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
-        #    "connectors": 48,  # Number of connectors
-        #},
-        #"sr-1-24d": {
-        #    "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
-        #    "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
-        #    "connectors": 24,  # Number of connectors
-        #},
-        #"sr-1-48d": {
-        #    "lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
-        #    "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
-        #    "connectors": 48,  # Number of connectors
-        #},
-        #"sr-1-92s": {
-        #    "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
-        #    "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
-        #    "connectors": 92,  # Number of connectors
-        #},
-        #"sr-1-46s": {
-        #    "lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
-        #    "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
-        #    "connectors": 46,  # Number of connectors
-        #},
-        #"sr-1x-92s": {
-        #    "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
-        #    "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
-        #    "connectors": 92,  # Number of connectors
-        #},
+        "sr-1x-48d": {
+            "lineCard": {"slot": "1", "type": "i48-800g-qsfpdd-1x"},
+            "mda": {"slot": "1-a", "type": "m48-800g-qsfpdd-1x"},
+            "connectors": 48,  # Number of connectors
+        },
+        "sr-1-24d": {
+            "lineCard": {"slot": "1", "type": "i24-800g-qsfpdd-1"},
+            "mda": {"slot": "1-a", "type": "m24-800g-qsfpdd-1"},
+            "connectors": 24,  # Number of connectors
+        },
+        "sr-1-48d": {
+            "lineCard": {"slot": "1", "type": "i48-400g-qsfpdd-1"},
+            "mda": {"slot": "1-a", "type": "m48-400g-qsfpdd-1"},
+            "connectors": 48,  # Number of connectors
+        },
+        "sr-1-92s": {
+            "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-400g-qsfpdd-1"},
+            "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-400g-qsfpdd-1"},
+            "connectors": 92,  # Number of connectors
+        },
+        "sr-1-46s": {
+            "lineCard": {"slot": "1", "type": "i40-200g-sfpdd+6-800g-qsfpdd-1"},
+            "mda": {"slot": "1-a", "type": "m40-200g-sfpdd+6-800g-qsfpdd-1"},
+            "connectors": 46,  # Number of connectors
+        },
+        "sr-1x-92s": {
+            "lineCard": {"slot": "1", "type": "i80-200g-sfpdd+12-800g-qsfpdd-1x"},
+            "mda": {"slot": "1-a", "type": "m80-200g-sfpdd+12-800g-qsfpdd-1x"},
+            "connectors": 92,  # Number of connectors
+        },
         ### SR-1se
         "sr-1se": {
             "lineCard": {"slot": "1", "type": "imm36-800g-qsfpdd"},
@@ -248,15 +248,36 @@ class NokiaSROSNode(Node):
         Returns
         -------
         str
-            The platform name (e.g. '7750 SR-1').
+            The platform name (e.g. '7750 SR-1', 'SR-1-48D', 'SR-2se').
         """
         if self.node_type and self.node_type.lower().startswith("sr-"):
-            # For SR-1, SR-7, SR-1s, etc. - preserve the exact case
-            # Only uppercase the "SR" part, keep the suffix as-is
-            if "-" in self.node_type:
-                parts = self.node_type.split("-", 1)
-                return f"7750 {parts[0].upper()}-{parts[1]}"
-            return f"7750 {self.node_type.upper()}"
+            # The platform string must match exactly the type reported by gNMIc, as EDA performs a case-sensitive platform comparison.
+            #
+            # Examples:
+            #   sr-1-48d   -> 7750 SR-1-48D
+            #   SR-1X-92S  -> 7750 SR-1x-92S
+            #   sr-1s      -> 7750 SR-1s
+            #   SR-2SE     -> 7750 SR-2se
+            #
+            # Rules:
+            # - Always uppercase the "SR" prefix.
+            # - For fixed-port platforms (SR-1-* and SR-1x-*), normalize the family to lowercase (1x) and uppercase only the final port designator (D/S), matching the value reported by gNMI.
+            # - For chassis platforms (SR-1s, SR-2se, SR-14s, ...), normalize the model suffix to lowercase.
+
+            node = self.node_type.strip()
+
+            # Normalize the SR prefix.
+            node = "SR-" + node[3:]
+
+            # Fixed-port platforms: SR-1-* and SR-1x-*.
+            match = re.fullmatch(r"SR-(1x|1)-(\d+)([a-z])", node, re.IGNORECASE)
+            if match:
+                family, ports, suffix = match.groups()
+                return f"7750 SR-{family.lower()}-{ports}{suffix.upper()}"
+
+            # Chassis platforms: normalize everything after "SR-" to lowercase.
+            return f"7750 SR-{node[3:].lower()}"
+
         return "7750 SR"  # Default fallback
 
     def is_eda_supported(self):

--- a/example-topologies/sros_fp4.yml
+++ b/example-topologies/sros_fp4.yml
@@ -1,0 +1,179 @@
+name: sros_fp4
+
+mgmt:
+  network: eda_mgmt
+  ipv4-subnet: 172.40.40.0/24
+
+topology:
+  kinds:
+    nokia_srlinux:
+      type: ixr-d3l
+      image: ghcr.io/nokia/srlinux:26.3.1
+      license: /opt/nokia/srl/srl_r25.10_license.key
+    linux:
+      image: ghcr.io/srl-labs/network-multitool
+    nokia_srsim:
+      type: sr-1-46s
+      image: registry.srlinux.dev/pub/nokia_srsim:26.3.R1
+      license: ${SROS_LIC_PATH:-/opt/nokia/sros/sr-sim_r25_license.key}
+
+  nodes:
+    ### DC A/100
+    dc-gw-101:
+      kind: nokia_srsim
+      type: sr-1
+      mgmt-ipv4: 172.40.40.101
+      license: /opt/nokia/sros/sr-sim_r25_license.key
+      #image: registry.srlinux.dev/pub/nokia_srsim:26.3.R1
+      #startup-config: configs/core/r1.partial.cfg
+    dc-gw-102:
+      kind: nokia_srsim
+      type: sr-1s
+      mgmt-ipv4: 172.40.40.102
+      license: /opt/nokia/sros/sr-sim_r25_license.key
+      #image: registry.srlinux.dev/pub/nokia_srsim:26.3.R1
+      #startup-config: configs/core/r2.partial.cfg
+
+      
+    spine-111:
+      kind: nokia_srlinux
+      type: ixr-d3l
+      mgmt-ipv4: 172.40.40.111
+      startup-config: config/all.partial.cfg
+    spine-112:
+      kind: nokia_srlinux
+      type: ixr-d3l
+      mgmt-ipv4: 172.40.40.112
+      startup-config: config/all.partial.cfg
+    leaf-121:
+      kind: nokia_srlinux
+      type: ixr-d3l
+      mgmt-ipv4: 172.40.40.121
+      startup-config: config/all.partial.cfg
+    leaf-122:
+      kind: nokia_srlinux
+      type: ixr-d3l
+      mgmt-ipv4: 172.40.40.122
+      startup-config: config/all.partial.cfg
+
+
+    ### DC B/200
+    dc-gw-201:
+      kind: nokia_srsim
+      type: sr-2s
+      license: /opt/nokia/sros/sr-sim_r25_license.key
+      env:
+        NOKIA_SROS_SFM: sfm-s 
+      components:
+        - slot: A
+          type: cpm-2s
+        - slot: 1
+      #image: ghcr.io/nokia/srlinux:25.10.3
+      mgmt-ipv4: 172.40.40.201
+      #startup-config: config/all.partial.cfg
+    # FP4 chassis
+    dc-gw-202:
+      kind: nokia_srsim
+      type: sr-7s
+      license: /opt/nokia/sros/sr-sim_r25_license.key
+      env:
+        NOKIA_SROS_SFM: sfm-s 
+      components:
+        - slot: A
+          sfm: sfm-s # FP4
+          type: cpm2-s
+        - slot: 1
+          type: xcm-7s # FP4
+          mda:
+            - slot: 1
+              type: s36-100gb-qsfp28 # FP4
+
+      #image: ghcr.io/nokia/srlinux:25.10.3
+      mgmt-ipv4: 172.40.40.202
+      #startup-config: config/all.partial.cfg
+    spine-211:
+      kind: nokia_srlinux
+      type: ixr-d3l
+      mgmt-ipv4: 172.40.40.211
+      startup-config: config/all.partial.cfg
+    leaf-221:
+      kind: nokia_srlinux
+      type: ixr-d3l
+      mgmt-ipv4: 172.40.40.221
+      startup-config: config/all.partial.cfg
+
+
+    ### CLIENTS ###
+    linux1:
+      kind: linux
+      exec:
+        - ip -6 address add 2002::192:168:51:1/96 dev eth1
+        - ip address add 192.168.51.1/24 dev eth1
+        - ip address add 192.168.52.1/24 dev eth2
+        - ip address add 192.168.53.1/24 dev eth3
+        - ip route add 192.168.63.0/24 via 192.168.53.254
+      mgmt-ipv4: 172.40.40.151
+      group: server
+    linux2:
+      kind: linux
+      exec:
+        - ip -6 address add 2002::192:168:51:2/96 dev eth1
+        - ip address add 192.168.51.2/24 dev eth1
+        - ip address add 192.168.52.2/24 dev eth2
+        - ip address add 192.168.63.2/24 dev eth3
+        - ip route add 192.168.53.0/24 via 192.168.63.254
+      mgmt-ipv4: 172.40.40.152
+      group: server
+    linux3:
+      kind: linux
+      exec:
+        - ip -6 address add 2002::192:168:51:2/96 dev eth1
+        - ip address add 192.168.51.3/24 dev eth1
+        - ip address add 192.168.52.3/24 dev eth2
+        - ip address add 192.168.63.3/24 dev eth3
+        - ip route add 192.168.53.0/24 via 192.168.63.254
+      mgmt-ipv4: 172.40.40.153
+      group: server
+
+  links:
+    # Interconnect DC-GWs
+    # dc-gw-101
+    - endpoints: ["dc-gw-101:1/1/c1/1", "dc-gw-102:1/1/c1/1"]
+    - endpoints: ["dc-gw-101:1/1/c2/1", "dc-gw-201:1/1/c2/1"]
+    - endpoints: ["dc-gw-101:1/1/c3/1", "spine-111:e1-1"]
+    - endpoints: ["dc-gw-101:1/1/c4/1", "spine-112:e1-2"]
+    # dc-gw-102
+    - endpoints: ["dc-gw-102:1/1/c2/1", "dc-gw-202:1/1/c2/1"]
+    - endpoints: ["dc-gw-102:1/1/c3/1", "spine-111:e1-2"]
+    - endpoints: ["dc-gw-102:1/1/c4/1", "spine-112:e1-1"]
+    # dc-gw-201
+    - endpoints: ["dc-gw-201:1/1/c1/1", "dc-gw-202:1/1/c1/1"]
+    - endpoints: ["dc-gw-201:1/1/c3/1", "spine-211:e1-1"]
+    # dc-gw-202
+    - endpoints: ["dc-gw-202:1/1/c3/1", "spine-211:e1-2"]
+
+
+    # DC A/100
+    # spine-111
+    - endpoints: ["spine-111:e1-3", "leaf-121:e1-1"]
+    - endpoints: ["spine-111:e1-4", "leaf-122:e1-2"]
+    # spine-112
+    - endpoints: ["spine-112:e1-3", "leaf-122:e1-1"]
+    - endpoints: ["spine-112:e1-4", "leaf-121:e1-2"]
+    # leaf-121
+    - endpoints: ["leaf-121:e1-3", "linux1:eth1"]
+    - endpoints: ["leaf-121:e1-4", "linux1:eth2"]
+    - endpoints: ["leaf-121:e1-5", "linux1:eth3"]
+    #- endpoints: ["leaf-122:e1-4", "linux1:eth2"]
+    - endpoints: ["leaf-122:e1-3", "linux2:eth1"]
+    - endpoints: ["leaf-122:e1-4", "linux2:eth2"]
+    - endpoints: ["leaf-122:e1-5", "linux2:eth3"]
+
+
+    # DC B/200
+    # spine-211
+    - endpoints: ["spine-211:e1-3", "leaf-221:e1-1"]
+    # leaf-221
+    - endpoints: ["leaf-221:e1-3", "linux3:eth1"]
+    - endpoints: ["leaf-221:e1-4", "linux3:eth2"]
+    - endpoints: ["leaf-221:e1-5", "linux3:eth3"]

--- a/example-topologies/sros_fp5.yml
+++ b/example-topologies/sros_fp5.yml
@@ -1,0 +1,107 @@
+name: sros_fp5
+
+mgmt:
+  network: eda_mgmt
+  ipv4-subnet: 172.40.40.0/24
+
+topology:
+  kinds:
+    nokia_srsim:
+      #type: sr-1-46s
+      image: registry.srlinux.dev/pub/nokia_srsim:26.3.R1
+      license: ${SROS_LIC_PATH:-/opt/nokia/sros/sr-sim_r25_license.key}
+
+  nodes:
+    ### SR-1 FP5 
+    sr-1x-48d:
+      kind: nokia_srsim
+      type: sr-1x-48d
+      mgmt-ipv4: 172.40.40.151
+      #license: /opt/nokia/sros/sr-sim_r25_license.key
+      components:
+        - slot: A
+        - slot: 1
+    sr-1-24d:
+      kind: nokia_srsim
+      type: sr-1-24d
+      mgmt-ipv4: 172.40.40.152
+      components:
+        - slot: A
+        - slot: 1
+    sr-1-48d:
+      kind: nokia_srsim
+      type: sr-1-48d
+      mgmt-ipv4: 172.40.40.153
+      components:
+        - slot: A
+        - slot: 1
+    sr-1-92s:
+      kind: nokia_srsim
+      type: sr-1-92s
+      mgmt-ipv4: 172.40.40.154
+      components:
+        - slot: A
+        - slot: 1
+    sr-1-46s:
+      kind: nokia_srsim
+      type: sr-1-46s
+      mgmt-ipv4: 172.40.40.155
+      components:
+        - slot: A
+        - slot: 1
+    sr-1x-92s:
+      kind: nokia_srsim
+      type: sr-1x-92s
+      mgmt-ipv4: 172.40.40.156
+      components:
+        - slot: A
+        - slot: 1
+    ### SR-1se FP5 
+    sr-1se:
+      kind: nokia_srsim
+      type: sr-1se
+      mgmt-ipv4: 172.40.40.161
+      components:
+        - slot: A
+        - slot: 1
+    ### SR-2se FP5 
+    sr-2se:
+      kind: nokia_srsim
+      type: sr-2se
+      mgmt-ipv4: 172.40.40.171
+      env:
+        NOKIA_SROS_SFM: sfm-2se 
+      components:
+        - slot: A
+          type: cpm-2se
+        - slot: 1
+          type: xcm-2se #
+          mda:
+            - slot: 1
+              type: x2-s36-800g-qsfpdd-18.0t
+          #xiom:
+          #  - slot: 1 # XIOM slot x1
+          #    type: x2-s36-800g-qsfpdd-6.0t # maps to NOKIA_SROS_XIOM_X1 env var
+          #    mda:  # mdas are nested *under* the XIOM
+          #      - slot: 1 # mda x1/1
+          #        type: m36-800g-qsfpdd # maps to NOKIA_SROS_MDA_X1_1 env var
+    ### SR-14s FP5
+    sr-14s:
+      kind: nokia_srsim
+      type: sr-14s
+      mgmt-ipv4: 172.40.40.181
+      env:
+        NOKIA_SROS_SFM: sfm2-s
+      components:
+        - slot: A
+          type: cpm2-s
+          sfm: sfm2-s
+        - slot: 1
+          type: xcm2-14s #
+          mda:
+            - slot: 1
+              type: x2-s36-800g-qsfpdd-18.0t 
+
+
+
+


### PR DESCRIPTION
This PR introduces support for sros fp5 integrated models (SR-1/SR-1x)
This is a follow-up of PR #218 , please review it before this one.

The `get_platform` was changed to fix the error below:
```
failed commit apply: error_str:"Platform mismatch '7750 SR-1x-92S' != '7750 SR-1x-92s'"
```

The correction solve the issue for all models:
```
[root@Airframe3 clab-connector]# kubectl -n clab-eda-fp5 get toponodes
NAME        PLATFORM         VERSION   OS     ONBOARDED   MODE   NPP         NODE     AGE
sr-1-24d    7750 SR-1-24D    26.3.r1   sros   true               Connected   Synced   20m
sr-1-46s    7750 SR-1-46S    26.3.r1   sros   true               Connected   Synced   20m
sr-1-48d    7750 SR-1-48D    26.3.r1   sros   true               Connected   Synced   20m
sr-1-92s    7750 SR-1-92S    26.3.r1   sros   true               Connected   Synced   20m
sr-14s      7750 SR-14s      26.3.r1   sros   true               Connected   Synced   20m
sr-1se      7750 SR-1se      26.3.r1   sros   true               Connected   Synced   20m
sr-1x-48d   7750 SR-1x-48D   26.3.r1   sros   true               Connected   Synced   20m
sr-1x-92s   7750 SR-1x-92S   26.3.r1   sros   true               Connected   Synced   20m
sr-2se      7750 SR-2se      26.3.r1   sros   true               Connected   Synced   20m
[root@Airframe3 clab-connector]# 
```